### PR TITLE
:newspaper: add pyecharts, pyecharts-snapshot and jupyter-echarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 - [Languages](#languages)
     - [JavaScript](#javascript)
     - [Python](#python)
+    - [Jupyter Notebook](#jupyter-notebook)
     - [R](#r)
     - [Julia](#julia)
     - [PureScript](#purescript)
@@ -89,8 +90,14 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 
 ### Python
 
+- [pyecharts](https://github.com/chenjiandongx/pyecharts) by chenjiandong
+- [pyecharts-snapshot](https://github.com/chfw/pyecharts-snapshot) by C. W.
 - [echarts-python](https://github.com/yufeiminds/echarts-python) @yufeiminds - Generate Echarts options with Python.
 - [krisk](https://github.com/napjon/krisk) @napjon - Statistical Interactive Visualization with pandas+Jupyter integration on top of Echarts.
+
+### Jupyter-Notebook
+
+- [jupyter-echarts](https://github.com/chfw/jupyter-echarts) by C. W.
 
 ### R
 


### PR DESCRIPTION
- pyecharts for Python
- pyecharts-snapshot for rendering pyecharts as static images
- jupyter-echarts for bringing echarts js to Jupyter book and for hosting echarts for export notebooks, custom flask&django projects.