### PR TITLE
add flutter_echarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
     - [React Native Component](#react-native-component)
     - [Vue Component](#vue-component)
 - [Languages](#languages)
+    - [Dart](#dart)
     - [Golang](#golang)
     - [iOS](#ios)
     - [Java](#java)
@@ -95,6 +96,10 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 - [vue-echarts-v3](https://github.com/xlsdg/vue-echarts-v3) @xlsdg - Vue.js(v2.x+) component wrap for ECharts.js(v3.x+).
 
 ## Languages
+
+### Dart
+
+- 🇨🇳 [flutter_echarts](https://github.com/entronad/flutter_echarts) @entronad - A Flutter widget to use Echarts in a reactive way.
 
 ### Golang
 


### PR DESCRIPTION
在 Flutter 中使用 Echarts 的组件：[flutter_echarts](https://github.com/entronad/flutter_echarts)，
详细介绍请见博文：[中文](https://zhuanlan.zhihu.com/p/99034738) | [EN](https://medium.com/@entronad/reactive-echarts-flutter-widget-fedab7f3c52f) .
使用示例请见：[example](https://github.com/entronad/flutter_echarts/tree/master/example) .
