### PR TITLE
Add Java Library for ECharts 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 ### Java
 
 - 🇨🇳 [ECharts-Java](https://github.com/abel533/ECharts) @Liuzh_533 - 一个供Java开发使用的ECharts的开发包。
+- 🇨🇳 [ECharts Java](https://github.com/ECharts-Java/ECharts-Java) @IcePear-Jzx @incandescentxxc  A Java data visualization library based on ECharts 5.x
 
 ### JavaScript
 


### PR DESCRIPTION
Currently, there is only one Java library for ECharts in the list. Unfortunately, it is no longer maintained and can only support ECharts 3.x. In view of this, we created ECharts Java, which is a data visualization library based on ECharts 5.x. 

You can find the complete doc in both Chinese and English [here](https://echarts.icepear.org/#/). The repo is [here](https://github.com/ECharts-Java/ECharts-Java).

Thank you and look forward to contributing to this list.