### PR TITLE
docs: add ngx-echarts to Angular Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
     - [Videos](#videos)
 - [Extensions](#extensions)
 - [Frameworks](#frameworks)
+    - [Angular Component](#angular-component)
     - [AngularJS Binding](#angularjs-binding)
     - [Blazor Binding](#blazor-binding)
     - [Flutter Component](#flutter-component)
@@ -79,6 +80,11 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 - [echarts-extension-gmap](https://github.com/plainheart/echarts-extension-gmap) - A [Google Map](https://www.google.com/maps) extension for Apache ECharts.
 
 ## Frameworks
+
+
+### Angular Component
+
+- [ngx-echarts](https://github.com/xieziyu/ngx-echarts) @xieziyu - Angular (ver >= 2.x) directive for ECharts.
 
 ### AngularJS Binding
 


### PR DESCRIPTION
文档中维护的 AngularJS 相关的框架资源都比较古早了，皆无法适用于 Angular 2 以上版本。
这里推荐的 [ngx-echarts](https://github.com/xieziyu/ngx-echarts) 是目前仍在活跃维护的 Angular Directive 封装，最新已支持到 Angular 14 以上的项目。

项目包含[在线示例](https://xieziyu.github.io/ngx-echarts)

----

The AngularJS-Binding framework resources maintained in this documentation are deprecated and cannot be applied to Angular 2 or later.
The [ngx-echarts](https://github.com/xieziyu/ngx-echarts) recommended here is the Angular Directive that is still actively maintained, and is applicable to projects using Angular 14 or above.

Project contains [online demo](https://xieziyu.github.io/ngx-echarts)