### PR TITLE
Add Apache ECharts HTTP Export Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 
 ### HTTP Server
 
-- [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server) @xiaomaiyun - This is a Node.js-based service, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG , PDF and Base64) to be sent back to the user..
+- [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server) @xiaomaiyun - This is a Node.js-based service, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG, PDF and Base64) to be sent back to the user..
 
 ### iOS
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
     - [Clojure](#clojure)
     - [Dart](#dart)
     - [Golang](#golang)
-    - [HTTP Server](#http-server)
     - [iOS](#ios)
     - [Java](#java)
     - [JavaScript](#javascript)
@@ -136,10 +135,6 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 
 - 🇨🇳 [go-echarts](https://github.com/chenjiandongx/go-echarts) @chenjiandongx - The adorable charts library for Golang.
 
-### HTTP Server
-
-- [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server) @xiaomaiyun - This is a Node.js-based service, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG, PDF and Base64) to be sent back to the user.
-
 ### iOS
 
 - 🇨🇳 [iOS-Echarts](https://github.com/Pluto-Y/iOS-Echarts) @Pluto-Y - This is a highly custom chart control for iOS and Mac apps, which build with the EChart(Echart2).
@@ -171,6 +166,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 
 - [echarts-scrappeteer](https://github.com/chfw/echarts-scrappeteer) @chfw - Puppeteer! Scrape all echarts from this web page please!
 - 🇨🇳 [node-echarts](https://github.com/suxiaoxin/node-echarts) @suxiaoxin - 后台生成ECharts图表
+- [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server) @xiaomaiyun - This is a Node.js-based service, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG, PDF and Base64) to be sent back to the user.
 
 ### PureScript
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 
 - 🇨🇳 [go-echarts](https://github.com/chenjiandongx/go-echarts) @chenjiandongx - The adorable charts library for Golang.
 
+### HTTP Server
+
+- [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server) @xiaomaiyun - This is a Node.js-based service, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG , PDF and Base64) to be sent back to the user..
+
 ### iOS
 
 - 🇨🇳 [iOS-Echarts](https://github.com/Pluto-Y/iOS-Echarts) @Pluto-Y - This is a highly custom chart control for iOS and Mac apps, which build with the EChart(Echart2).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
     - [Clojure](#clojure)
     - [Dart](#dart)
     - [Golang](#golang)
+    - [HTTP Server](#http-server)
     - [iOS](#ios)
     - [Java](#java)
     - [JavaScript](#javascript)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ _提示：带有「🇨🇳」的项目为中文资源，或包含中文文档�
 
 ### HTTP Server
 
-- [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server) @xiaomaiyun - This is a Node.js-based service, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG, PDF and Base64) to be sent back to the user..
+- [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server) @xiaomaiyun - This is a Node.js-based service, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG, PDF and Base64) to be sent back to the user.
 
 ### iOS
 


### PR DESCRIPTION
Add Apache ECharts HTTP Export Server

Currently, there is no HTTP Export Server ( Server Side Rendering ) for ECharts. In view of this, we created [Apache ECharts HTTP Export Server](https://github.com/xiaomaigou/echarts-export-server). The export server is a Node.js-based service, which is easy to install and integrate on any system. It accepts either JSON-formatted chart options or SVGs, together with additional resources, and uses node canvas to render Apache ECharts charts to images (PNG, JPG, SVG , PDF and Base64) to be sent back to the user.The application can be used either as a CLI (Command Line Interface), as an HTTP server, or as a node.js module.. 

The repo is [here](https://github.com/xiaomaigou/echarts-export-server).

Thank you and look forward to contributing to this list.